### PR TITLE
Add custom message for xRules

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -16,12 +16,7 @@
       >
         <div class="form-control">
           <label for="email" class="label">Zipcode</label>
-          <input
-            class="input"
-            placeholder="xxxxx-xxxxx"
-            type="text"
-            data-rules="nullable|x-regex:zipcode|x-min:min-from-server"
-          />
+          <input class="input" placeholder="xxxxx-xxxxx" type="text" data-rules="nullable|x-regex:zipcode" />
         </div>
         <div class="form-control mt-4">
           <label for="email" class="label"> Email </label>
@@ -71,8 +66,17 @@
             placeholder="Enter your password"
             class="input"
             type="password"
-            data-rules="required|string|min:5"
+            data-rules="required|string|x-regex:password"
           />
+          <small class="ml-2 mt-1 text-gray-500">
+            • 8 Characters minimum
+            <br />
+            • At least one uppercase letter
+            <br />
+            • At least one lowercase letter
+            <br />
+            • At least one special character (e.g. @, #, $, %, &, *, etc.)
+          </small>
         </div>
 
         <div class="mt-4">

--- a/playground/index.html
+++ b/playground/index.html
@@ -7,6 +7,7 @@
     <title>Facile Validator - Demo</title>
     <meta name="description" content="Laravel-inspired validation for HTML forms, built for simplicity of use" />
   </head>
+
   <body class="font-roboto min-h-screen w-full flex flex-col bg-gray-100 select-none">
     <main class="w-full flex-auto flex flex-col items-center justify-center px-3 sm:px-12 py-8">
       <form
@@ -19,7 +20,7 @@
             class="input"
             placeholder="xxxxx-xxxxx"
             type="text"
-            data-rules="nullable|x-regex:zipcode|x-min:min-from-server"
+            data-rules="nullable|x-regex:myZipCode|x-min:min-from-server"
           />
         </div>
         <div class="form-control mt-4">

--- a/playground/index.html
+++ b/playground/index.html
@@ -20,7 +20,7 @@
             class="input"
             placeholder="xxxxx-xxxxx"
             type="text"
-            data-rules="nullable|x-regex:myZipCode|x-min:min-from-server"
+            data-rules="nullable|x-regex:zipcode|x-min:min-from-server"
           />
         </div>
         <div class="form-control mt-4">

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -14,31 +14,45 @@ const v = new Validator(form, {
   onFieldChangeValidation: true,
   onFieldChangeValidationDelay: 500,
   xRules: {
-    zipcode: /^([0-9]{5})-([0-9]{5})$/,
-    myZipCode: {
-      errorText: (field) => {
-        console.log(field.value);
+    zipcode: '/^([0-9]{5})-([0-9]{5})$/',
+    password: {
+      value: /^(?=.*[A-Z])(?=.*[a-z])(?=.*[@#$%^&*]).{8,}$/,
+      errorMessage: (field) => {
+        if (field.value.length < 8) {
+          return 'Password must be at least 8 characters';
+        }
+
+        if (!/[A-Z]/.test(field.value)) {
+          return 'Password must contain at least one uppercase letter';
+        }
+
+        if (!/[a-z]/.test(field.value)) {
+          return 'Password must contain at least one lowercase letter';
+        }
+
+        if (!/[@#$%^&*]/.test(field.value)) {
+          return 'Password must contain at least one special character';
+        }
+
         return 'My custom error message';
       },
-      pattern: '/^([0-9]{5})-([0-9]{5})$/',
     },
-    'min-from-server': 5,
   },
   on: {
     'validation:success': () => {
       alert('Success! Form validated without any errors');
     },
     'validation:end': () => {
-      console.log('validation:end');
+      // console.log('validation:end');
     },
     'validation:start': () => {
-      console.log('validation:start');
+      // console.log('validation:start');
     },
     'validation:failed': () => {
-      console.log('validation:failed');
+      // console.log('validation:failed');
     },
     'field:error': () => {
-      console.log('field:error');
+      // console.log('field:error');
     },
   },
 });

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -22,7 +22,7 @@ const v = new Validator(form, {
       },
       pattern: '/^([0-9]{5})-([0-9]{5})$/',
     },
-    'min-from-server': (() => '2')(),
+    'min-from-server': 5,
   },
   on: {
     'validation:success': () => {

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -14,7 +14,11 @@ const v = new Validator(form, {
   onFieldChangeValidation: true,
   onFieldChangeValidationDelay: 500,
   xRules: {
-    zipcode: '/^([0-9]{5})-([0-9]{5})$/',
+    zipcode: /^([0-9]{5})-([0-9]{5})$/,
+    myZipCode: {
+      errorText: 'Please enter a valid zip code',
+      pattern: '/^([0-9]{5})-([0-9]{5})$/',
+    },
     'min-from-server': (() => '2')(),
   },
   on: {

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -16,7 +16,10 @@ const v = new Validator(form, {
   xRules: {
     zipcode: /^([0-9]{5})-([0-9]{5})$/,
     myZipCode: {
-      errorText: 'Please enter a valid zip code',
+      errorText: (field) => {
+        console.log(field.value);
+        return 'My custom error message';
+      },
       pattern: '/^([0-9]{5})-([0-9]{5})$/',
     },
     'min-from-server': (() => '2')(),

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -14,7 +14,10 @@ const v = new Validator(form, {
   onFieldChangeValidation: true,
   onFieldChangeValidationDelay: 500,
   xRules: {
-    zipcode: '/^([0-9]{5})-([0-9]{5})$/',
+    zipcode: {
+      value: '/^([0-9]{5})-([0-9]{5})$/',
+      errorMessage: 'Invalid zipcode',
+    },
     password: {
       value: /^(?=.*[A-Z])(?=.*[a-z])(?=.*[@#$%^&*]).{8,}$/,
       errorMessage: (field) => {

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -43,16 +43,16 @@ const v = new Validator(form, {
       alert('Success! Form validated without any errors');
     },
     'validation:end': () => {
-      // console.log('validation:end');
+      console.log('validation:end');
     },
     'validation:start': () => {
-      // console.log('validation:start');
+      console.log('validation:start');
     },
     'validation:failed': () => {
-      // console.log('validation:failed');
+      console.log('validation:failed');
     },
     'field:error': () => {
-      // console.log('field:error');
+      console.log('field:error');
     },
   },
 });

--- a/src/facile-validator.ts
+++ b/src/facile-validator.ts
@@ -97,7 +97,12 @@ class Validator {
               const result = rules[ruleKey](value, ruleArgs);
 
               if (result instanceof RuleError) {
-                this.validatorError.setError(field, ruleName, result, customErrorText);
+                let customMessage = '';
+
+                if (customErrorText) {
+                  customMessage = typeof customErrorText === 'function' ? customErrorText(field) : customErrorText;
+                }
+                this.validatorError.setError(field, ruleName, result, customMessage);
                 if (shouldStopOnFirstFailure) {
                   break;
                 }

--- a/src/facile-validator.ts
+++ b/src/facile-validator.ts
@@ -85,7 +85,11 @@ class Validator {
         const computedFieldRules = this.getComputedFieldRules(fieldRules, field);
 
         for (const fieldRule of computedFieldRules) {
-          const { name: ruleName, argsValue: ruleArgs, customErrorText } = processRule(fieldRule, this.options.xRules);
+          const {
+            name: ruleName,
+            argsValue: ruleArgs,
+            customErrorMessage,
+          } = processRule(fieldRule, this.options.xRules);
           const ruleKey = toCamelCase(ruleName) as RuleKey;
 
           if (this.isNullable(ruleKey) && value === '') {
@@ -99,8 +103,9 @@ class Validator {
               if (result instanceof RuleError) {
                 let customMessage = '';
 
-                if (customErrorText) {
-                  customMessage = typeof customErrorText === 'function' ? customErrorText(field) : customErrorText;
+                if (customErrorMessage) {
+                  customMessage =
+                    typeof customErrorMessage === 'function' ? customErrorMessage(field) : customErrorMessage;
                 }
                 this.validatorError.setError(field, ruleName, result, customMessage);
                 if (shouldStopOnFirstFailure) {

--- a/src/facile-validator.ts
+++ b/src/facile-validator.ts
@@ -85,7 +85,7 @@ class Validator {
         const computedFieldRules = this.getComputedFieldRules(fieldRules, field);
 
         for (const fieldRule of computedFieldRules) {
-          const { name: ruleName, argsText: ruleArgs } = processRule(fieldRule, this.options.xRules);
+          const { name: ruleName, argsValue: ruleArgs, customErrorText } = processRule(fieldRule, this.options.xRules);
           const ruleKey = toCamelCase(ruleName) as RuleKey;
 
           if (this.isNullable(ruleKey) && value === '') {
@@ -97,7 +97,7 @@ class Validator {
               const result = rules[ruleKey](value, ruleArgs);
 
               if (result instanceof RuleError) {
-                this.validatorError.setError(field, ruleName, result);
+                this.validatorError.setError(field, ruleName, result, customErrorText);
                 if (shouldStopOnFirstFailure) {
                   break;
                 }

--- a/src/modules/rule-adapter.ts
+++ b/src/modules/rule-adapter.ts
@@ -29,7 +29,7 @@ export function prependType(
   _parentEl: HTMLElement,
   xRules?: XRules
 ): string {
-  const { name, argsText } = processRule(rule, xRules);
+  const { name, argsValue } = processRule(rule, xRules);
 
   const indexOfRule = rules.indexOf(rule);
   const rulesBeforeRule = rules.slice(0, indexOfRule);
@@ -41,7 +41,7 @@ export function prependType(
     type = 'array';
   }
 
-  return `${name}:${type},${argsText}`;
+  return `${name}:${type},${argsValue}`;
 }
 
 function prependTargetValue(

--- a/src/modules/validator-error.ts
+++ b/src/modules/validator-error.ts
@@ -12,7 +12,7 @@ export default class ValidatorError {
     this.errorsList = [];
   }
 
-  public setError(element: FormInputElement, rule: string, ruleError: RuleError) {
+  public setError(element: FormInputElement, rule: string, ruleError: RuleError, customMessage = '') {
     let errors = this.errorsList.find((error) => error[0].element === element);
 
     if (!errors) {
@@ -20,7 +20,7 @@ export default class ValidatorError {
       this.errorsList.push(errors);
     }
 
-    const errorMessage = lang(ruleError.message, ...ruleError.args);
+    const errorMessage = customMessage || lang(ruleError.message, ...ruleError.args);
 
     const errorDetail: ErrorDetail = {
       message: errorMessage,

--- a/src/rules/min.ts
+++ b/src/rules/min.ts
@@ -8,7 +8,6 @@ function min(value: string, args = ''): true | RuleError {
   const [type, min] = processArgs(args);
   when(!type).throwError(ARGUMENT_MUST_BE_PROVIDED);
   when(!min).throwError(ARGUMENT_MUST_BE_PROVIDED);
-
   const minInNumber = Number(min);
   when(Number.isNaN(minInNumber)).throwError(ARGUMENT_MUST_BE_A_NUMBER);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export type RichXRule = { errorText?: string | ((field: FormInputElement) => str
 export type LangKeys = ErrorCause[keyof ErrorCause];
 export type Lang = Partial<Record<LangKeys, string>>;
 export type RuleName = typeof rules[keyof typeof rules];
-export type XRules = Record<string, string | RegExp | RichXRule>;
+export type XRules = Record<string, number | string | RegExp | RichXRule>;
 export type RuleKey = keyof typeof rules;
 
 export interface ValidatorOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,11 +6,13 @@ export type ArrayOfValues<T> = {
 };
 
 type ErrorCause = typeof rules;
-export type RichXRule = { errorText?: string | ((field: FormInputElement) => string); pattern: string };
+type FieldArgTypes = string | number | RegExp;
+
+export type RichXRule = { errorMessage?: string | ((field: FormInputElement) => string); value: FieldArgTypes };
 export type LangKeys = ErrorCause[keyof ErrorCause];
 export type Lang = Partial<Record<LangKeys, string>>;
 export type RuleName = typeof rules[keyof typeof rules];
-export type XRules = Record<string, number | string | RegExp | RichXRule>;
+export type XRules = Record<string, FieldArgTypes | RichXRule>;
 export type RuleKey = keyof typeof rules;
 
 export interface ValidatorOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export type ArrayOfValues<T> = {
 };
 
 type ErrorCause = typeof rules;
-export type RichXRule = { errorText?: string; pattern: string };
+export type RichXRule = { errorText?: string | ((field: FormInputElement) => string); pattern: string };
 export type LangKeys = ErrorCause[keyof ErrorCause];
 export type Lang = Partial<Record<LangKeys, string>>;
 export type RuleName = typeof rules[keyof typeof rules];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,10 +6,11 @@ export type ArrayOfValues<T> = {
 };
 
 type ErrorCause = typeof rules;
+export type RichXRule = { errorText?: string; pattern: string };
 export type LangKeys = ErrorCause[keyof ErrorCause];
 export type Lang = Partial<Record<LangKeys, string>>;
 export type RuleName = typeof rules[keyof typeof rules];
-export type XRules = Record<string, unknown>;
+export type XRules = Record<string, string | RegExp | RichXRule>;
 export type RuleKey = keyof typeof rules;
 
 export interface ValidatorOptions {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -7,7 +7,7 @@ export function toCamelCase(value: string) {
   return value.replace(/-./g, (match) => match[1].toUpperCase());
 }
 
-export function getValue(element: FormInputElement): string {
+export function getValue(element: FormInputElement) {
   if (element instanceof HTMLInputElement) {
     if (element.type === TYPE_CHECKBOX || element.type === TYPE_RADIO) {
       return element.checked ? 'checked' : '';
@@ -33,17 +33,9 @@ export function format(message: string, ...toReplace: string[]) {
   return message.replace(/\$(\d)/g, (_, index) => toReplace?.[index - 1] || '');
 }
 
-export function processRule(
-  rule: string,
-  xRules?: XRules
-): {
-  name: string;
-  argsValue: string;
-  args: string[];
-  customErrorText?: string;
-} {
+export function processRule(rule: string, xRules?: XRules) {
   let [name, argsValue = ''] = rule.split(':');
-  let customErrorText = '';
+  let customErrorText: RichXRule['errorText'] = '';
 
   if (isXRule(rule)) {
     if (!hasArgument(rule)) {
@@ -69,11 +61,11 @@ export function processRule(
   };
 }
 
-export function processArgs(args: string): string[] {
+export function processArgs(args: string) {
   return args ? args.split(',') : [];
 }
 
-export function lang(key: string, ...args: string[]): string {
+export function lang(key: string, ...args: string[]) {
   const languages = Language.get();
   let item = key;
 
@@ -118,7 +110,7 @@ export function hasArgument(rule: string) {
   return rule.includes(':') && rule.split(':').length === 2;
 }
 
-export function isXRule(rule: string): boolean {
+export function isXRule(rule: string) {
   return rule.startsWith('x-');
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -35,7 +35,7 @@ export function format(message: string, ...toReplace: string[]) {
 
 export function processRule(rule: string, xRules?: XRules) {
   let [name, argsValue = ''] = rule.split(':');
-  let customErrorText: RichXRule['errorText'] = '';
+  let customErrorMessage: RichXRule['errorMessage'] = '';
 
   if (isXRule(rule)) {
     if (!hasArgument(rule)) {
@@ -46,18 +46,21 @@ export function processRule(rule: string, xRules?: XRules) {
 
     if (isObject(xRules?.[argsValue])) {
       const rule = xRules?.[argsValue] as RichXRule;
-      customErrorText = rule.errorText || '';
-      argsValue = String(rule.pattern);
+      customErrorMessage = rule.errorMessage || '';
+      argsValue = String(rule.value);
     } else {
       argsValue = String(xRules?.[argsValue]) || '';
     }
   }
+  console.log(rule, customErrorMessage);
+  // const stack = new Error().stack;
+  // console.log(stack);
 
   return {
     name,
     argsValue,
     args: processArgs(argsValue),
-    customErrorText,
+    customErrorMessage,
   };
 }
 

--- a/tests/utils/process-args.test.ts
+++ b/tests/utils/process-args.test.ts
@@ -7,4 +7,5 @@ it('should process args correctly', () => {
   expect(processArgs('arg1,arg2')).toEqual(['arg1', 'arg2']);
   expect(processArgs(',arg2')).toEqual(['', 'arg2']);
   expect(processArgs('arg1,')).toEqual(['arg1', '']);
+  expect(processArgs(String(/^([0-9]{5})-([0-9]{5})$/))).toEqual(['/^([0-9]{5})-([0-9]{5})$/']);
 });

--- a/tests/utils/process-rule.test.ts
+++ b/tests/utils/process-rule.test.ts
@@ -6,7 +6,7 @@ it('should process "accepted" correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe('');
+  expect(result.argsValue).toBe('');
   expect(result.args).toHaveLength(0);
 });
 
@@ -15,7 +15,7 @@ it('should process "accepted:" correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe('');
+  expect(result.argsValue).toBe('');
   expect(result.args).toHaveLength(0);
 });
 
@@ -24,7 +24,7 @@ it('should process "accepted:arg1" correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe('arg1');
+  expect(result.argsValue).toBe('arg1');
   expect(result.args).toEqual(['arg1']);
 });
 
@@ -33,7 +33,7 @@ it('should process "accepted:arg1,arg2" correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe('arg1,arg2');
+  expect(result.argsValue).toBe('arg1,arg2');
   expect(result.args).toEqual(['arg1', 'arg2']);
 });
 
@@ -42,7 +42,7 @@ it('should process "accepted:,arg2" correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe(',arg2');
+  expect(result.argsValue).toBe(',arg2');
   expect(result.args).toEqual(['', 'arg2']);
 });
 
@@ -51,6 +51,6 @@ it('should process "accepted:arg1," correctly', () => {
   const result = processRule(rule);
 
   expect(result.name).toBe('accepted');
-  expect(result.argsText).toBe('arg1,');
+  expect(result.argsValue).toBe('arg1,');
   expect(result.args).toEqual(['arg1', '']);
 });


### PR DESCRIPTION
This PR adds the functionality to support custom error messages for an x-regex rule.

Previously, there was no way to display a custom message when an x-regex rule failed; Instead, a generic 'The value doesn't match the pattern' would be displayed.

With this PR, we can now display customized messages based on arbitrary conditions:

```js
const v = new Validator(form, {
  // ...
  xRules: {
    /* If the value is an object typeof RichXRule,
     * a custom message will be displayed based on
     * arbitrary conditions */
    password: {
      errorText: (field) => {
        if (!hasSpecialCharacters(field.value)) {
          return "Password should have special characters";
        }

        return 'Invalid password';
      },
      pattern: '/^(A_PATTERN)$/',
    },

    // Even simpler, errorText can also be typeof string
    myRegex: {
      pattern: /^[A-Za-z]$/,
      errorText: 'Please enter only alphabetical characters',
    } 

    /* Simple rule,
     * no configurations,
     * displays default error message */
    myMin: 6,
  },
```

HTML:
```html
<div class="form-control">
  <label for="password" class="label">Password</label>
  <input
    class="input"
    type="text"
    data-rules="nullable|x-regex:password|x-min:myMin"
  />
</div>
```
