### PR TITLE
add option to disable invisible fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ const v = new Validator(form, {
 
 <br/>
 
+### Validate only visible fields
+
+With the option `disableInvisibleFields` you are able to decide, if you want to validate invisible fields. Invisible means in this case, fields which are not visible for the user (f.e. it's inside a collapsed option). This gives you the power to create dynamic forms with fields belongs to selected options before - and a validation of only required fields.
+
+```js
+const v = new Validator(form, {
+  disableInvisibleFields: true,
+}
+```
+
+<br/>
+
 ### Getting Field Values
 
 Use `values()` method from the validator to get the values of all fields in the form:

--- a/src/facile-validator.ts
+++ b/src/facile-validator.ts
@@ -1,7 +1,7 @@
 import * as rules from '@/rules';
 import { ValidatorOptions, EventsName, Events, FormInputElement, Lang } from '@/types';
 import ValidatorError from '@/modules/validator-error';
-import { getValue, toCamelCase, defaultErrorListeners, processRule } from '@/utils/helpers';
+import { getValue, toCamelCase, defaultErrorListeners, processRule, checkFieldVisibility } from '@/utils/helpers';
 import EventBus from './modules/events';
 import Language from './modules/language';
 import { RuleError } from './modules/rule-error';
@@ -12,6 +12,7 @@ type RuleKey = keyof typeof rules;
 const defaultOptions: ValidatorOptions = {
   renderErrors: true,
   onFieldChangeValidationDelay: 500,
+  disableInvisibleFields: false,
 };
 
 class Validator {
@@ -97,6 +98,10 @@ class Validator {
         const value = getValue(field);
         const shouldStopOnFirstFailure = this.shouldStopOnFirstFailure(fieldRules);
         const computedFieldRules = this.getComputedFieldRules(fieldRules, field);
+		
+		if (this.options.disableInvisibleFields && !checkFieldVisibility(field)) {
+			continue;
+		}
 
         for (const fieldRule of computedFieldRules) {
           const {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface ValidatorOptions {
   xRules?: XRules;
   onFieldChangeValidation?: boolean;
   onFieldChangeValidationDelay?: number;
+  disableInvisibleFields?: boolean;
 }
 
 export interface Rule {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -117,3 +117,22 @@ export function isXRule(rule: string) {
 export function isObject(obj: unknown) {
   return typeof obj === 'object' && obj !== null && Object.getPrototypeOf(obj) === Object.prototype;
 }
+
+export function checkFieldVisibility(field: FormInputElement) {
+	// check base field visibility options
+	const style = window.getComputedStyle(field);
+	const invisible = style.display === "none" || style.visibility === "hidden" || field.offsetParent === null;
+
+	if (!invisible) return true; // field id visible: validate it
+
+	// field is in a closed collapse: DONT validate
+	const collapse = field.closest('.collapse');
+	if (collapse && !collapse.classList.contains('show')) return false;
+
+	// special case: field is inside a bootstrap .tab-pane: validate it
+	const tabPane = field.closest('.tab-pane');
+	if (tabPane) return true;
+
+	// Otherwise: field is invisible and not inside a tab pane → DONT validate
+	return false;
+}


### PR DESCRIPTION
With this PR a new option is added to disable invisible fields. This can be helpful if you have dynamic forms and some fields are related to entered options. So fields which become invisible while the form is filled out won't be validated - and fields which become visible will be validated.