### PR TITLE
Export RuleError from rule-error module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export {
 } from '@/locales';
 
 export * from '@/types';
+export { RuleError } from '@/modules/rule-error';


### PR DESCRIPTION
Add RuleError to list of exported APIs.

This change is good for implementing a custom wrapper with custom rules which are to specific to include it into this library.
Wir the Export it is possible to wrap the whole library and use all core functionalities.